### PR TITLE
Implement parameter destructuring

### DIFF
--- a/scripts/generate-ci.ts
+++ b/scripts/generate-ci.ts
@@ -21,9 +21,6 @@ async function main(): Promise<void> {
         if (!await HelperFS.exists(SERVER_DIR + "/db.ts")) {
             await fs.writeFile(SERVER_DIR + "/db.ts", "export const _ = true;");
         }
-        if (!await HelperFS.exists(SERVER_DIR + "/db-init.ts")) {
-            await fs.writeFile(SERVER_DIR + "/db-init.ts", "export const _ = true;");
-        }
         // compile from the generated indexes
         await exec("npm run compile", { cwd: SERVER_DIR });
     } catch (err) {

--- a/server/api/interfaces/IHttpController.ts
+++ b/server/api/interfaces/IHttpController.ts
@@ -5,7 +5,7 @@ import WebServer from "../../WebServer";
 abstract class IHttpController extends IRequestHandler {
     public actions: {[key: string]: string} = {};
     public authRequired: string[] = [];
-    public params: {[key: string]: string[]} = {};
+    public params?: {[key: string]: string[]} = {};
     public permsRequired: {[key: string]: any[]} = {};
     public raw: string[] = [];
     public routes: string[] = [];

--- a/server/api/mvc.ts
+++ b/server/api/mvc.ts
@@ -25,6 +25,7 @@ export default class MVC {
             if (!target.prototype.routes) target.prototype.routes = [];
             if (!target.prototype.actions) target.prototype.actions = {};
             if (!target.prototype.raw) target.prototype.raw = [];
+            if (!target.prototype.params) target.prototype.params = {};
             if (!target.prototype.authRequired) target.prototype.authRequired = [];
             if (!target.prototype.permsRequired) target.prototype.permsRequired = {};
         };

--- a/server/api/mvc.ts
+++ b/server/api/mvc.ts
@@ -25,7 +25,6 @@ export default class MVC {
             if (!target.prototype.routes) target.prototype.routes = [];
             if (!target.prototype.actions) target.prototype.actions = {};
             if (!target.prototype.raw) target.prototype.raw = [];
-            if (!target.prototype.params) target.prototype.params = {};
             if (!target.prototype.authRequired) target.prototype.authRequired = [];
             if (!target.prototype.permsRequired) target.prototype.permsRequired = {};
         };


### PR DESCRIPTION
* Controller actions should not use `@eta.mvc.params()` any more - it's now deprecated in favor of destructured parameters, like so: `public async foo({ bar }: { bar: number }): Promise<void> { ...`
  * See [the Typescript documentation](https://www.typescriptlang.org/docs/handbook/variable-declarations.html#destructuring) for more information.