### PR TITLE
new mechanism to authorize as a user in test files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 index.ts
 .DS_Store
 .vscode
+package-lock.json

--- a/lib/TestRunner.ts
+++ b/lib/TestRunner.ts
@@ -4,29 +4,36 @@ import * as supertest from "supertest";
 export default class TestRunner {
     private agent: supertest.SuperTest<supertest.Test>;
     private pathPrefix: string;
+    private apiToken: string;
 
-    public constructor(baseUrl = "http://localhost:3000", pathPrefix = "") {
+    public constructor(baseUrl = "http://localhost:3000", pathPrefix = "", apiToken = "ari5END35D__53") {
         this.agent = supertest.agent(baseUrl);
         this.pathPrefix = pathPrefix;
+        this.apiToken = apiToken;
     }
 
+    // Pass a userId in the options to authorize as this user.
     public request(url: string, options?: Partial<RequestOptions>): supertest.Test {
         if (!url.startsWith("/")) url = this.pathPrefix + url;
         options = _.defaults<Partial<RequestOptions>, Partial<RequestOptions>>(options, {
             method: "get",
-            apiToken: process.env.API_TOKEN,
+            userId: undefined,
             params: {}
         });
         let req: supertest.Test = this.agent[options.method].bind(this.agent)(url);
-        if (options.apiToken !== undefined) req = req.set("Authorization", "Bearer " + options.apiToken);
+        req.set("x-requested-with", "XMLHttpRequest"); // tells eta to not forward to a login page
+        if (options.userId !== undefined) {
+            req.set("Authorization", `Basic ${options.userId}:${this.apiToken}`);
+        }
         if (options.method === "get") req = req.query(options.params);
-        else req = req.send(options.params).type("form");
+        // this seems to be a problem => it turns numbers into strings
+        else req = req.send(options.params);
         return req;
     }
 }
 
 interface RequestOptions {
     method: "get" | "post" | "patch" | "put" | "delete";
-    apiToken: string;
+    userId: number;
     params: {[key: string]: any};
 }

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "@types/useragent": "^2.1.1",
     "@types/uuid": "^3.4.3",
     "@types/winston": "^2.3.9",
-    "@xroadsed/eta-cli": "^1.3.17",
+    "@xroadsed/eta-cli": "^1.3.19",
     "chai": "^4.1.2",
     "supertest": "^3.0.0"
   },

--- a/tslint.json
+++ b/tslint.json
@@ -30,7 +30,7 @@
     "no-for-in-array": true,
     "no-inferrable-types": true,
     "no-internal-module": true,
-    "no-null-keyword": true,
+    "no-null-keyword": false,
     "no-return-await": true,
     "no-string-literal": true,
     "no-string-throw": true,


### PR DESCRIPTION
- pass `userId` as a parameter to `TestRunner::request()` to authorize as that user for the request. The user keeps logged in after the request. To send a request with no user logged in, pass `null` as the `userId`. Thi authentication mechanism only works if `enable: true` is set in the `dev.json` config file.